### PR TITLE
Oops, wasn't actually fixed! Addendum to previous PR!

### DIFF
--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -161,6 +161,10 @@ def test_regression():
     # Weighting is a Gaussian width 1000 when this was made
     # In the future, this should be True, but random seeds not working rn.
     config['source_phot_ops'] = False
+
+    with open("config.yaml", "w") as f:
+        yaml.dump(config, f)
+
     os.system('python RomanASP.py -s 40120913 -b Y106 -t 2 -d 1 -o \
               "tests/testdata"')
     current = pd.read_csv('tests/testdata/40120913_Y106_romanpsf_lc.ecsv',

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -162,11 +162,14 @@ def test_regression():
     # In the future, this should be True, but random seeds not working rn.
     config['source_phot_ops'] = False
 
-    with open("config.yaml", "w") as f:
-        yaml.dump(config, f)
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)\
+            as temp_config:
+        yaml.dump(config, temp_config)
+        temp_config_path = temp_config.name
+    os.system(f'python RomanASP.py -s 40120913 -b Y106 -t 2 -d 1 -o \
+              "tests/testdata" --config {temp_config_path}')
 
-    os.system('python RomanASP.py -s 40120913 -b Y106 -t 2 -d 1 -o \
-              "tests/testdata"')
     current = pd.read_csv('tests/testdata/40120913_Y106_romanpsf_lc.ecsv',
                           comment='#')
     comparison = pd.read_csv('tests/testdata/test_lc.ecsv', comment='#')

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -8,6 +8,7 @@ import galsim
 import numpy as np
 import os
 import pandas as pd
+import tempfile
 import warnings
 import yaml
 
@@ -162,7 +163,6 @@ def test_regression():
     # In the future, this should be True, but random seeds not working rn.
     config['source_phot_ops'] = False
 
-    import tempfile
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)\
             as temp_config:
         yaml.dump(config, temp_config)

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -48,8 +48,6 @@ Adapted from code by Pedro Bernardinelli
 '''
 
 
-
-
 def load_config(config_path):
     """Load parameters from a YAML configuration file."""
     with open(config_path, 'r') as file:
@@ -58,7 +56,6 @@ def load_config(config_path):
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="Can overwrite config file")
 
     parser.add_argument('-b', '--band', type=str, required=True, help='filter')
@@ -117,8 +114,6 @@ def main():
     mismatch_seds = config['mismatch_seds']
     fetch_SED = config['fetch_SED']
     makecontourGrid = config['makecontourGrid']
-
-
 
     roman_bandpasses = galsim.roman.getBandpasses()
 

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -47,8 +47,7 @@ Adapted from code by Pedro Bernardinelli
 
 '''
 
-config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                           'config.yaml')
+
 
 
 def load_config(config_path):
@@ -74,6 +73,21 @@ def main():
 
     parser.add_argument('-o', '--output_path', type=str, required=False,
                         help='relative output path')
+
+    parser.add_argument('-c', '--config', type=str, required=False,
+                        help='relative config file path')
+
+    args = parser.parse_args()
+    band = args.band
+    SNID = args.SNID
+    testnum = args.testnum
+    detim = args.detim
+    output_path = args.output_path
+    if args.config is not None:
+        config_path = args.config
+    else:
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           'config.yaml')
 
     config = load_config(config_path)
 
@@ -104,12 +118,7 @@ def main():
     fetch_SED = config['fetch_SED']
     makecontourGrid = config['makecontourGrid']
 
-    args = parser.parse_args()
-    band = args.band
-    SNID = args.SNID
-    testnum = args.testnum
-    detim = args.detim
-    output_path = args.output_path
+
 
     roman_bandpasses = galsim.roman.getBandpasses()
 

--- a/tests/testdata/test_lc.ecsv
+++ b/tests/testdata/test_lc.ecsv
@@ -4,13 +4,14 @@
 # - {name: MJD, unit: d, datatype: float64}
 # - {name: true_flux, datatype: float64}
 # - {name: measured_flux, datatype: float64}
+# - {name: flux_error, datatype: float64}
 # meta:
 #   __serialized_columns__:
 #     MJD:
 #       __class__: astropy.units.quantity.Quantity
 #       unit: !astropy.units.Unit {unit: d}
 #       value: !astropy.table.SerializedColumn {name: MJD}
-#   confusion_metric: 42.94320595545287
+#   confusion_metric: 42.83799231012745
 #   host_dec: -44.919194
 #   host_mag_g: 25.508
 #   host_ra: 7.344728
@@ -18,5 +19,5 @@
 #   sn_dec: -44.91922993380131
 #   sn_ra: 7.344774044463684
 # schema: astropy-2.0
-MJD true_flux measured_flux
-62535.424 6361.0 5323.110196892974
+MJD true_flux measured_flux flux_error
+62535.424 6361.0 5323.110196892974 227.10545742080097


### PR DESCRIPTION
In the regression test, the config file was not actually being written to before running the test, causing it to fail. This has now been fixed. Also, I made it so that it now checks if the flux error matches the saved lightcurve as well.
You may notice the confusion metric is different in each file. That's fine because the confusion_metric still has randomness in it and is not being used as a part of the test.