### PR TITLE
HOTFIX: Determining object type in a non-terrible way

### DIFF
--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -163,7 +163,8 @@ def test_run_on_star():
         temp_config_path = temp_config.name
 
     err_code = os.system(f'python RomanASP.py -s 40973149150 -f Y106 -t 1 -d 1\
-                          -o "tests/testdata" --config {temp_config_path}')
+                          -o "tests/testdata" --config {temp_config_path}\
+                          --object_type star')
     assert err_code == 0, "The test run on a star failed. Check the logs"
 
 

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -718,20 +718,22 @@ def fetchImages(testnum, detim, ID, sn_path, band, size, fit_background,
     ID: int, the ID of the object
     sn_path: str, the path to the supernova data
     band: str, the band to be used
-    size: int, the size of the cutout to be used
+    size: int, cutout will be of shape (size, size)
     fit_background: bool, whether to manually fit the background or not
     roman_path: str, the path to the Roman data
     obj_type: str, the type of object to be used (SN or star)
     lc_start, lc_end: ints, MJD bounds on where to fetch images.
 
     Returns:
-    images: array, the actual image data
+    images: array, the actual image data, shape (num_total_images, size, size)
     cutout_wcs_list: list of wcs objects for the cutouts
     im_wcs_list: list of wcs objects for the entire SCA
-    err: array, the error data
-    snra: float, the RA of the supernova
-    sndec: float, the DEC of the supernova
-    exposures: table of exposures used
+    err: array, the uncertainty in each pixel
+                of images, shape (num_total_images, size, size)
+    snra, sndec: floats, the RA and DEC of the supernova, a single float is
+                         used for both of these as we assume the object is
+                         not moving between exposures.
+    exposures: astropy.table.table.Table, table of exposures used
 
     '''
 
@@ -749,6 +751,10 @@ def fetchImages(testnum, detim, ID, sn_path, band, size, fit_background,
     images, cutout_wcs_list, im_wcs_list, err =\
         constructImages(exposures, ra, dec, size=size,
                         background=fit_background, roman_path=roman_path)
+
+    Lager.debug(f'here {np.shape(images)}')
+    Lager.debug(f'here {np.shape(err)}')
+    Lager.debug(f'here {type(exposures)}')
 
     return images, cutout_wcs_list, im_wcs_list, err, snra, sndec, ra, dec, \
            exposures

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -707,17 +707,39 @@ def getPSF_Image(self,stamp_size,x=None,y=None, x_center = None, y_center= None,
 
 
 def fetchImages(testnum, detim, ID, sn_path, band, size, fit_background,
-                roman_path, lc_start=-np.inf, lc_end=np.inf):
-    if len(str(ID)) != 8:
-        object_type = 'star'
-    else:
-        object_type = 'SN'
+                roman_path, object_type, lc_start=-np.inf, lc_end=np.inf):
+    '''
+    This function gets the list of exposures to be used for the analysis.
 
-    pqfile = find_parq(ID, sn_path, obj_type = object_type)
+    Inputs:
+    num_total_images: total images used in analysis (detection + no detection)
+    num_detect_images: number of images used in the analysis that contain a
+                       detection.
+    ID: int, the ID of the object
+    sn_path: str, the path to the supernova data
+    band: str, the band to be used
+    size: int, the size of the cutout to be used
+    fit_background: bool, whether to manually fit the background or not
+    roman_path: str, the path to the Roman data
+    obj_type: str, the type of object to be used (SN or star)
+    lc_start, lc_end: ints, MJD bounds on where to fetch images.
+
+    Returns:
+    images: array, the actual image data
+    cutout_wcs_list: list of wcs objects for the cutouts
+    im_wcs_list: list of wcs objects for the entire SCA
+    err: array, the error data
+    snra: float, the RA of the supernova
+    sndec: float, the DEC of the supernova
+    exposures: table of exposures used
+
+    '''
+
+    pqfile = find_parq(ID, sn_path, obj_type=object_type)
     ra, dec, p, s, start, end, peak = \
             get_object_info(ID, pqfile, band = band, snpath = sn_path, roman_path = roman_path, obj_type = object_type)
     snra = ra
-    sndec = dec
+    sndec = dec # Why is this here? TODO remove in a less urgent PR
     start = start[0]
     end = end[0]
     exposures = findAllExposures(ID, ra, dec, peak, start, end,
@@ -729,7 +751,7 @@ def fetchImages(testnum, detim, ID, sn_path, band, size, fit_background,
                         background=fit_background, roman_path=roman_path)
 
     return images, cutout_wcs_list, im_wcs_list, err, snra, sndec, ra, dec, \
-           exposures, object_type
+           exposures
 
 
 def get_object_info(ID, parq, band, snpath, roman_path, obj_type):

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To actually have the code serve your specific needs, you can modify the yaml fil
 | make_initial_guess     | bool   | If true, the algorithm uses an average of the pixel values at each model point to set an initial guess for each model point. Slight improvement in certain cases but not pivotal. |
 | source_phot_ops        | bool   | If true, use photon shooting to generate the PSF for fitting the SN. This seemingly needs to be true for a quality fit.     |
 | flux_initial_guess | float | When we make the initial guess, every model component gets a starting value. This includes the supernova fluxes. Setting this value chooses the initial flux for the SN in each image before the algorithm solves for the true value. Changing this number has very very little effect on the results and can be safely left at 1. It is only a configuration variable because I thought it was not smart to hard code it. |
+|object_type| str | What kind of object are we fitting? 'SN' for supernova, 'star' for star. This difference is important, as a star won't have predetection images, while a transient will. |
 
 
 ### Simulating your own images.

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -101,6 +101,11 @@ def main():
                         help='end of desired light curve in days from peak.',
                         default=np.inf)
 
+    parser.add_argument('--object_type', type=str, required=False,
+                        help='If star, will run on stars. If SN, will run  ' +
+                             'on supernovae. If None, assumes supernova.',
+                        default='SN')
+
     args = parser.parse_args()
     band = args.filter
     SNID = args.SNID
@@ -109,9 +114,7 @@ def main():
     output_path = args.output_path
     lc_start = args.beginning
     lc_end = args.end
-
-
-
+    object_type = args.object_type
 
     if args.config is not None:
         config_path = args.config
@@ -188,12 +191,10 @@ def main():
             # and load those as images.
             # TODO: Calculate peak MJD outside of the function
             images, cutout_wcs_list, im_wcs_list, err, snra, sndec, ra, dec, \
-                exposures, object_type = fetchImages(testnum, detim, ID,
-                                                     sn_path, band, size,
-                                                     fit_background,
-                                                     roman_path,
-                                                     lc_start=lc_start,
-                                                     lc_end=lc_end)
+                exposures = fetchImages(testnum, detim, ID, sn_path, band,
+                                        size, fit_background, roman_path,
+                                        object_type, lc_start=lc_start,
+                                        lc_end=lc_end)
             if len(exposures[~exposures['DETECTED']]) == 0:
                 Lager.warning('No pre-detection images found in time range ' +
                               'provided, skipping this object.')

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -102,8 +102,10 @@ def main():
                         default=np.inf)
 
     parser.add_argument('--object_type', type=str, required=False,
+                        choices=["star", "SN"],
                         help='If star, will run on stars. If SN, will run  ' +
-                             'on supernovae. If None, assumes supernova.',
+                             'on supernovae. If no argument is passed,' +
+                             'assumes supernova.',
                         default='SN')
 
     args = parser.parse_args()


### PR DESCRIPTION
In this PR I: 
1. [x] Have object_type be an argument rather than dynamically determined from the ID (far too reliant on the sims).
2. [x] Added a docstring for fetchImages while I was in there.
3. [x] Modified the test that runs a star to reflect the new argument that needs to be passed.
4. [x] Updated readme with the new argument
This passes all tests. I did not add any new tests as no new functions were made.