### PR TITLE
Snappl refactor

### DIFF
--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -543,7 +543,7 @@ def gaussian(x, A, mu, sigma):
 
 
 def constructImages(exposures, ra, dec, size=7, background=False,
-                    roman_path=None):
+                    roman_path=None, truth='simple_model'):
 
     '''
     Constructs the array of Roman images in the format required for the linear algebra operations
@@ -562,8 +562,6 @@ def constructImages(exposures, ra, dec, size=7, background=False,
     '''
 
     bgflux = []
-    truth = 'simple_model'
-
     image_list = []
     cutout_image_list = []
 


### PR DESCRIPTION
In this PR, we:
1. [x] Refactor ConstructImages so that it returns Image objects
2. [x] However, the rest of the code does not use Image objects yet. So, temporarily, I turn the Image objects back into the numpy arrays that the rest of the code expects. 
Passes all tests!