### PR TITLE
Refactor make grid, Part 2

### DIFF
--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -268,10 +268,8 @@ def test_regular_grid():
     for key in wcs.keys():
         wcs[key] = wcs[key].item()
     wcs = galsim.wcs.readFromFitsHeader(wcs)[0]
-    ra_grid, dec_grid = local_grid(ra_center, dec_center, wcs,
-                                   size=25, spacing=3.0, image=None,
-                                   percentiles=[],
-                                   makecontourGrid=False)
+    ra_grid, dec_grid = regular_grid(ra_center, dec_center, wcs,
+                                   size=25, spacing=3.0)
     test_ra = np.array([7.67363133, 7.67373506, 7.67383878, 7.67355803,
                         7.67366176, 7.67376548, 7.67348473, 7.67358845,
                         7.67369218])
@@ -293,34 +291,24 @@ def test_adaptive_grid():
     wcs = galsim.wcs.readFromFitsHeader(wcs)[0]
     compare_images = np.load('tests/testdata/images.npy')
     image = compare_images[:11**2].reshape(11, 11)
-    ra_grid, dec_grid = local_grid(ra_center, dec_center, wcs,
-                                   size=11, spacing=3.0, image=image,
-                                   percentiles=[99],
-                                   makecontourGrid=False)
-    test_ra = [7.67356034, 7.67366407, 7.67376779, 7.67348704, 7.67358874,
-               7.67357896, 7.67360257, 7.67359279, 7.67369449, 7.67341373,
-               7.67351746, 7.67362119]
-    test_dec = [-44.26425446, -44.26420403, -44.26415359, -44.26418244,
-                -44.26414017, -44.26413057, -44.26413345, -44.26412385,
-                -44.26408158, -44.26411043, -44.26405999, -44.26400956]
-    assert np.allclose(ra_grid, test_ra, rtol=1e-7), "RA vals do not match"
-    assert np.allclose(dec_grid, test_dec, rtol=1e-7), "Dec vals do not match"
+    ra_grid, dec_grid = make_adaptive_grid(ra_center, dec_center, wcs,
+                                           image=image, percentiles=[99])
+    test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407, 7.67369864,]
+    test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403, -44.26418721]
+    assert np.allclose(ra_grid[:5], test_ra, rtol=1e-7), "RA vals do not match"
+    assert np.allclose(dec_grid[:5], test_dec, rtol=1e-7), "Dec vals do not match"
 
 
 def test_contour_grid():
     from AllASPFuncs import local_grid
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
-    ra_center = wcs['CRVAL1']
-    dec_center = wcs['CRVAL2']
     for key in wcs.keys():
         wcs[key] = wcs[key].item()
     wcs = galsim.wcs.readFromFitsHeader(wcs)[0]
     compare_images = np.load('tests/testdata/images.npy')
     image = compare_images[:11**2].reshape(11, 11)
-    ra_grid, dec_grid = local_grid(ra_center, dec_center, wcs,
-                                   size=11, spacing=3.0, image=image,
-                                   makecontourGrid=True)
+    ra_grid, dec_grid = contourGrid(image, wcs)
     test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407]
     test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403]
     msg = "RA vals do not match"

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -275,8 +275,8 @@ def test_make_regular_grid():
     test_dec = np.array([-44.26396874, -44.26391831, -44.26386787,
                          -44.26389673, -44.26384629, -44.26379586,
                          -44.26382471, -44.26377428, -44.26372384])
-    assert np.allclose(ra_grid, test_ra, rtol=1e-7), "RA vals do not match"
-    assert np.allclose(dec_grid, test_dec, rtol=1e-7), "Dec vals do not match"
+    assert np.allclose(ra_grid, test_ra, atol=1e-7), "RA vals do not match"
+    assert np.allclose(dec_grid, test_dec, atol=1e-7), "Dec vals do not match"
 
 
 def test_make_adaptive_grid():
@@ -293,8 +293,8 @@ def test_make_adaptive_grid():
                                            image=image, percentiles=[99])
     test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407, 7.67369864,]
     test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403, -44.26418721]
-    assert np.allclose(ra_grid[:5], test_ra, rtol=1e-7), "RA vals do not match"
-    assert np.allclose(dec_grid[:5], test_dec, rtol=1e-7), "Dec vals do not match"
+    assert np.allclose(ra_grid[:5], test_ra, atol=1e-7), "RA vals do not match"
+    assert np.allclose(dec_grid[:5], test_dec, atol=1e-7), "Dec vals do not match"
 
 
 def test_make_contour_grid():
@@ -309,22 +309,22 @@ def test_make_contour_grid():
     test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407]
     test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403]
     msg = "RA vals do not match"
-    assert np.allclose(ra_grid[:4], test_ra, rtol=1e-7), msg
+    assert np.allclose(ra_grid[:4], test_ra, atol=1e-7), msg
     msg = "Dec vals do not match"
-    assert np.allclose(dec_grid[:4], test_dec, rtol=1e-7), msg
+    assert np.allclose(dec_grid[:4], test_dec, atol=1e-7), msg
 
 
 def test_calculate_background_level():
     from AllASPFuncs import calculate_background_level
     test_data = np.ones((12, 12))
     test_data[5:7, 5:7] = 1000
-    test_data[0:2, 0:12:2] = 10
-    test_data[-3:-1, 0:12:2] = 10
-    test_data[0:12:2, 0:2] = 10
-    test_data[0:12:2, -1:-3] = 10  # Adding some noise
-    # Expected output
-    expected_output = 1
+    test_data[0:2, 0:12:2] = 123
+    test_data[-3:-1, 0:12:2] = 123
+    test_data[0:12:2, 0:2] = 123
+    test_data[0:12:2, -1:-3] = 123  # Adding some outliers to prevent all of
+    # the data from being sigma clipped.
 
+    expected_output = 1
     output = calculate_background_level(test_data)
     msg = f"Expected {expected_output}, but got {output}"
     assert np.isclose(output, expected_output, rtol=1e-7), msg

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -179,7 +179,7 @@ def test_regression():
     config['use_roman'] = True
     config['use_real_images'] = True
     config['fetch_SED'] = False
-    config['makecontourGrid'] = True
+    config['contour_grid'] = True
     config['band'] = 'Y106'
     config['adaptive_grid'] = True
     config['turn_grid_off'] = False
@@ -259,7 +259,7 @@ def test_plot_lc():
     assert output[5] == 0.0
 
 
-def test_regular_grid():
+def test_make_regular_grid():
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     ra_center = wcs['CRVAL1']
@@ -267,7 +267,7 @@ def test_regular_grid():
     for key in wcs.keys():
         wcs[key] = wcs[key].item()
     wcs = galsim.wcs.readFromFitsHeader(wcs)[0]
-    ra_grid, dec_grid = regular_grid(ra_center, dec_center, wcs,
+    ra_grid, dec_grid = make_regular_grid(ra_center, dec_center, wcs,
                                    size=25, spacing=3.0)
     test_ra = np.array([7.67363133, 7.67373506, 7.67383878, 7.67355803,
                         7.67366176, 7.67376548, 7.67348473, 7.67358845,
@@ -279,7 +279,7 @@ def test_regular_grid():
     assert np.allclose(dec_grid, test_dec, rtol=1e-7), "Dec vals do not match"
 
 
-def test_adaptive_grid():
+def test_make_adaptive_grid():
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     ra_center = wcs['CRVAL1']
@@ -297,7 +297,7 @@ def test_adaptive_grid():
     assert np.allclose(dec_grid[:5], test_dec, rtol=1e-7), "Dec vals do not match"
 
 
-def test_contour_grid():
+def test_make_contour_grid():
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     for key in wcs.keys():
@@ -305,7 +305,7 @@ def test_contour_grid():
     wcs = galsim.wcs.readFromFitsHeader(wcs)[0]
     compare_images = np.load('tests/testdata/images.npy')
     image = compare_images[:11**2].reshape(11, 11)
-    ra_grid, dec_grid = contourGrid(image, wcs)
+    ra_grid, dec_grid = make_contour_grid(image, wcs)
     test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407]
     test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403]
     msg = "RA vals do not match"
@@ -321,7 +321,7 @@ def test_calculate_background_level():
     test_data[0:2, 0:12:2] = 10
     test_data[-3:-1, 0:12:2] = 10
     test_data[0:12:2, 0:2] = 10
-    test_data[0:12:2, -1:-3] = 10 # Adding some noise
+    test_data[0:12:2, -1:-3] = 10  # Adding some noise
     # Expected output
     expected_output = 1
 

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -159,7 +159,7 @@ def test_run_on_star():
     config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'config.yaml')
     config = yaml.safe_load(open(config_path))
-    config['turn_grid_off'] = True
+    config['grid_type'] = 'none'
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)\
             as temp_config:
@@ -181,8 +181,6 @@ def test_regression():
     config['fetch_SED'] = False
     config['grid_type'] = 'contour'
     config['band'] = 'Y106'
-    config['adaptive_grid'] = True
-    config['turn_grid_off'] = False
     config['size'] = 19
     config['weighting'] = True
     config['subtract_background'] = True

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -316,11 +316,13 @@ def test_calculate_background_level():
     from AllASPFuncs import calculate_background_level
     test_data = np.ones((12, 12))
     test_data[5:7, 5:7] = 1000
+
+    # Add some outliers to prevent all of
+    # the data from being sigma clipped.
     test_data[0:2, 0:12:2] = 123
     test_data[-3:-1, 0:12:2] = 123
     test_data[0:12:2, 0:2] = 123
-    test_data[0:12:2, -1:-3] = 123  # Adding some outliers to prevent all of
-    # the data from being sigma clipped.
+    test_data[0:12:2, -1:-3] = 123
 
     expected_output = 1
     output = calculate_background_level(test_data)

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -260,7 +260,6 @@ def test_plot_lc():
 
 
 def test_regular_grid():
-    from AllASPFuncs import local_grid
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     ra_center = wcs['CRVAL1']
@@ -281,7 +280,6 @@ def test_regular_grid():
 
 
 def test_adaptive_grid():
-    from AllASPFuncs import local_grid
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     ra_center = wcs['CRVAL1']
@@ -300,7 +298,6 @@ def test_adaptive_grid():
 
 
 def test_contour_grid():
-    from AllASPFuncs import local_grid
     wcs = np.load('./tests/testdata/wcs_dict.npz', allow_pickle=True)
     wcs = dict(wcs)
     for key in wcs.keys():

--- a/ASP_tests.py
+++ b/ASP_tests.py
@@ -179,7 +179,7 @@ def test_regression():
     config['use_roman'] = True
     config['use_real_images'] = True
     config['fetch_SED'] = False
-    config['contour_grid'] = True
+    config['grid_type'] = 'contour'
     config['band'] = 'Y106'
     config['adaptive_grid'] = True
     config['turn_grid_off'] = False

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -70,7 +70,8 @@ Adapted from code by Pedro Bernardinelli
 '''
 
 
-def regular_grid(ra_center, dec_center, wcs, size, spacing=1.0, subsize = 9):
+def make_regular_grid(ra_center, dec_center, wcs, size, spacing=1.0,
+                      subsize = 9):
     '''
     Generates a regular grid around a RA-Dec center, choosing step size.
 
@@ -90,6 +91,7 @@ def regular_grid(ra_center, dec_center, wcs, size, spacing=1.0, subsize = 9):
 
 
     '''
+    Lager.debug('GRID TYPE: REGULARLY SPACED')
     difference = int((size - subsize)/2)
 
     x_center, y_center = wcs.toImage(ra_center, dec_center, units='deg')
@@ -143,6 +145,7 @@ def make_adaptive_grid(ra_center, dec_center, wcs,
     '''
     size = np.shape(image)[0]
     Lager.debug('image shape: {}'.format(np.shape(image)))
+    Lager.debug('GRID TYPE: ADAPTIVE')
     # Bin the image in logspace and allocate grid points based on the
     # brightness.
 
@@ -908,7 +911,6 @@ def makeGrid(adaptive_grid, images, size, ra, dec, cutout_wcs_list,
             ra_grid, dec_grid = make_contour_grid(images[0], cutout_wcs_list[0])
         else:
             ra_grid, dec_grid = make_adaptive_grid(ra, dec, cutout_wcs_list[0],
-                                                   size=size, spacing=1,
                                                    image=images[0],
                                                    percentiles=percentiles)
 
@@ -923,7 +925,7 @@ def makeGrid(adaptive_grid, images, size, ra, dec, cutout_wcs_list,
         if single_grid_point:
             ra_grid, dec_grid = [ra], [dec]
         else:
-            ra_grid, dec_grid = regular_grid(ra, dec, cutout_wcs_list[0],
+            ra_grid, dec_grid = make_regular_grid(ra, dec, cutout_wcs_list[0],
                                              size=size, spacing=0.75)
 
         if make_exact:
@@ -1348,6 +1350,7 @@ def make_contour_grid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 10
     xg, yg = np.meshgrid(x, y, indexing='ij')
     xg = xg.ravel()
     yg = yg.ravel()
+    Lager.debug('GRID TYPE: CONTOUR')
 
     if numlevels is not None:
         levels = list(np.linspace(np.min(image), np.max(image), numlevels))

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -78,7 +78,7 @@ def make_regular_grid(ra_center, dec_center, wcs, size, spacing=1.0,
     ra_center, dec_center: floats, coordinate center of the image
     wcs: the WCS of the image, currently a galsim.fitswcs.AstropyWCS object
     spacing: int, spacing of grid points in pixels.
-    subsize: Int, width of the grid in pixels.
+    subsize: int, width of the grid in pixels.
              Specify the width of the grid, which can be smaller than the
              image. For instance I could have an image that is 11x11 but a grid
              that is only 9x9.
@@ -140,7 +140,7 @@ def make_adaptive_grid(ra_center, dec_center, wcs,
                 points. If you have more bins, you could go even higher to
                 4x4 and 5x5 etc. These points are evenly spaced within the
                 pixel.
-    subsize: Int, width of the grid in pixels.
+    subsize: int, width of the grid in pixels.
              Specify the width of the grid, which can be smaller than the
              image. For instance I could have an image that is 11x11 but a grid
              that is only 9x9.
@@ -1373,7 +1373,7 @@ def make_contour_grid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 10
                 more bins, the more possible grid points could be placed in
                 that pixel.
 
-    subsize: Int, width of the grid in pixels.
+    subsize: int, width of the grid in pixels.
              Specify the width of the grid, which can be smaller than the
              image. For instance I could have an image that is 11x11 but a grid
              that is only 9x9.

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -182,13 +182,15 @@ def make_adaptive_grid(ra_center, dec_center, wcs,
                 pass
             elif num == 1:
                 xes.append(y)
-                ys.append(x)  #Why this? TODO
+                ys.append(x)  # I know I swap this because Astropy takes (y,x)
+                # order but I'd really like to iron out all the places I do
+                # this rather than doing it so off the cuff. TODO
             else:
                 xx = np.linspace(x - 0.6, x + 0.6, num+2)[1:-1]
                 yy = np.linspace(y - 0.6, y + 0.6, num+2)[1:-1]
                 X, Y = np.meshgrid(xx, yy)
                 ys.extend(list(X.flatten()))
-                xes.extend(list(Y.flatten())) #Why this? TODO
+                xes.extend(list(Y.flatten())) #...Like here. TODO
 
     xx = np.array(xes).flatten()
     yy = np.array(ys).flatten()
@@ -1385,8 +1387,8 @@ def make_contour_grid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 10
         x_totalgrid.extend(xg)
         y_totalgrid.extend(yg)
 
-    xx, yy = y_totalgrid, x_totalgrid # This was flipped in local_grid. I need
-    # to figure out why, and if it's necessary. #TODO
+    xx, yy = y_totalgrid, x_totalgrid # Here is another place I need to flip
+    # x and y. I'd like this to be more rigorous or at least clear.
     xx = np.array(xx)
     yy = np.array(yy)
     xx = xx.flatten()

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -885,7 +885,7 @@ def getWeights(cutout_wcs_list, size, snra, sndec, error=None,
 
 def makeGrid(adaptive_grid, images, size, ra, dec, cutout_wcs_list,
              percentiles=[], single_grid_point=False,
-             make_exact=False, make_contour_grid=False):
+             make_exact=False, contour_grid=False):
     '''
     This is a function that returns the locations for the model grid points
     used to model the background galaxy. There are several different methods
@@ -904,8 +904,8 @@ def makeGrid(adaptive_grid, images, size, ra, dec, cutout_wcs_list,
                     model grid points.
     '''
     if adaptive_grid:
-        if make_contour_grid:
-            ra_grid, dec_grid = contourGrid(images[0], cutout_wcs_list[0])
+        if contour_grid:
+            ra_grid, dec_grid = make_contour_grid(images[0], cutout_wcs_list[0])
         else:
             ra_grid, dec_grid = make_adaptive_grid(ra, dec, cutout_wcs_list[0],
                                                    size=size, spacing=1,
@@ -917,7 +917,7 @@ def makeGrid(adaptive_grid, images, size, ra, dec, cutout_wcs_list,
                                        size=size,  spacing=0.75,
                                        image=images[0],
                                        percentiles=percentiles,
-                                       makecontourGrid=makecontourGrid)
+                                       contour_grid=contour_grid)
         '''
     else:
         if single_grid_point:
@@ -1284,7 +1284,7 @@ def get_SN_SED(SNID, date, sn_path):
     return np.array(lam), np.array(flambda[bestindex])
 
 
-def contourGrid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 100],
+def make_contour_grid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 100],
                 subsize = 4):
     '''
     Construct a "contour grid" which allocates model grid points to model
@@ -1354,7 +1354,7 @@ def contourGrid(image, wcs, numlevels = None, percentiles = [0, 90, 98, 100],
     else:
         levels = list(np.percentile(image, percentiles))
 
-    Lager.debug(f'Using levels: {levels} in contourGrid')
+    Lager.debug(f'Using levels: {levels} in make_contour_grid')
 
     interp = RegularGridInterpolator((x, y), image, method='linear',
                                  bounds_error=False, fill_value=None)
@@ -1626,7 +1626,7 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
                    sn_path, size, band, fetch_SED, use_real_images, use_roman,
                    subtract_background, turn_grid_off, adaptive_grid,
                    make_initial_guess, initial_flux_guess, weighting, method,
-                   make_contour_grid, single_grid_point, pixel, source_phot_ops,
+                   contour_grid, single_grid_point, pixel, source_phot_ops,
                    lc_start, lc_end, do_xshift, bg_gal_flux, do_rotation, airy,
                    mismatch_seds, deltafcn_profile, noise, check_perfection,
                    avoid_non_linearity, sim_gal_ra_offset, sim_gal_dec_offset,
@@ -1700,7 +1700,7 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
                                      cutout_wcs_list,
                                      single_grid_point=single_grid_point,
                                      percentiles=percentiles,
-                                     make_contour_grid=make_contour_grid)
+                                     contour_grid=contour_grid)
     else:
         ra_grid = np.array([])
         dec_grid = np.array([])

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -167,7 +167,7 @@ def make_adaptive_grid(ra_center, dec_center, wcs,
     '''
     size = np.shape(image)[0]
     if subsize > size:
-        Lager.warning('subsize is larger than the image size  +
+        Lager.warning('subsize is larger than the image size '  +
                       f'{size} > {subsize}. This would cause model points to' +
                       ' be placed outside the image. Reducing subsize to' +
                       ' match the image size.')
@@ -925,7 +925,7 @@ def getWeights(cutout_wcs_list, size, snra, sndec, error=None,
 
 
 def makeGrid(grid_type, images, size, ra, dec, cutout_wcs_list,
-             percentiles=[], single_grid_point=False,
+             percentiles=[],
              make_exact=False):
     '''
     This is a function that returns the locations for the model grid points
@@ -962,20 +962,22 @@ def makeGrid(grid_type, images, size, ra, dec, cutout_wcs_list,
         ra_grid, dec_grid = make_regular_grid(ra, dec, cutout_wcs_list[0],
                                               size=size, spacing=0.75)
 
-    else:
-        if single_grid_point:
-            ra_grid, dec_grid = [ra], [dec]
+    if grid_type == 'single':
+        ra_grid, dec_grid = [ra], [dec]
 
-        if make_exact:
-            if single_grid_point:
-                galra = ra_grid[0]
-                galdec = dec_grid[0]
-            else:
-                galra = ra_grid[106]
-                galdec = dec_grid[106]
+    if make_exact:
+        if grid_type == 'single':
+            galra = ra_grid[0]
+            galdec = dec_grid[0]
+        else:
+            raise NotImplementedError
+            # I need to figure out how to turn the single grid point test
+            # into a test function.
+            galra = ra_grid[106]
+            galdec = dec_grid[106]
 
-        ra_grid = np.array(ra_grid)
-        dec_grid = np.array(dec_grid)
+    ra_grid = np.array(ra_grid)
+    dec_grid = np.array(dec_grid)
     return ra_grid, dec_grid
 
 
@@ -1667,7 +1669,7 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
                    sn_path, size, band, fetch_SED, use_real_images, use_roman,
                    subtract_background, turn_grid_off,
                    make_initial_guess, initial_flux_guess, weighting, method,
-                   grid_type, single_grid_point, pixel, source_phot_ops,
+                   grid_type, pixel, source_phot_ops,
                    lc_start, lc_end, do_xshift, bg_gal_flux, do_rotation, airy,
                    mismatch_seds, deltafcn_profile, noise, check_perfection,
                    avoid_non_linearity, sim_gal_ra_offset, sim_gal_dec_offset,
@@ -1739,7 +1741,6 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
             Lager.warning('For fitting stars, you probably dont want a grid.')
         ra_grid, dec_grid = makeGrid(grid_type, images, size, ra, dec,
                                      cutout_wcs_list,
-                                     single_grid_point=single_grid_point,
                                      percentiles=percentiles)
     else:
         ra_grid = np.array([])
@@ -1939,7 +1940,7 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
             f = 1
         else:
             f = 5000
-        if single_grid_point:
+        if grid_type == 'single':
             X[0] = f
         else:
             X = np.zeros_like(X)

--- a/AllASPFuncs.py
+++ b/AllASPFuncs.py
@@ -1667,7 +1667,7 @@ def prep_data_for_fit(images, err, sn_matrix, wgt_matrix):
 
 def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_path,
                    sn_path, size, band, fetch_SED, use_real_images, use_roman,
-                   subtract_background, turn_grid_off,
+                   subtract_background,
                    make_initial_guess, initial_flux_guess, weighting, method,
                    grid_type, pixel, source_phot_ops,
                    lc_start, lc_end, do_xshift, bg_gal_flux, do_rotation, airy,
@@ -1736,7 +1736,7 @@ def run_one_object(ID, object_type, num_total_images, num_detect_images, roman_p
                                   sn_path)
 
     # Build the background grid
-    if not turn_grid_off:
+    if not grid_type == 'none':
         if object_type == 'star':
             Lager.warning('For fitting stars, you probably dont want a grid.')
         ra_grid, dec_grid = makeGrid(grid_type, images, size, ra, dec,

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ initial WCS. |
 | Parameter          | Type  | Description                                                                                                                                |
 |---------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | pixel               | bool  | If true, use a pixel (tophat) function rather than a delta function to be convolved with the PSF in order to build the model.            |
-| subtract_background      | bool  | If False, add an extra parameter that fits for the mean sky background level. If true, subtract the SKYMEAN from the image header. |
+| fit_background      | bool  | If true, add an extra parameter that fits for the mean sky background level. Should be false since the exact number is in the image header. |
 
 
 ### Not currently used, to be removed.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ To actually have the code serve your specific needs, you can modify the yaml fil
 | Parameter             | Type  | Description                                                                                                                           |
 |------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------|
 | SNID                   | int    | ID of the supernova you want to fit.                                                                                            |
-| adaptive_grid          | bool   | If true, use the adaptive grid method. If false, use a standard (rectilinear) grid.                                                        |
+| grid_type        |  str  | regular: A regularly spaced grid.
+              adaptive: Points are placed in the image based on the brightness
+                        in each pixel.
+              contour: Points are placed by placing finer and finer regularly
+                        spaced grids in different contour levels of a linear
+                        interpolation of the image. See make_contour_grid for
+                        a more detailed explanation.
+              single: Place a single grid point. This is for sanity checking
+                      that the algroithm is drawing points where expected.                                              |
 | band                   | str    | Which Roman passband to use.                                                                                                   |
 | testnum                | int    | Total number of images to utilize in the SMP algorithm.                                                                        |
 | detim                  | int    | Number of images with a SN detection in them. Rule of thumb, this should be 1/2 or less of testnum.                           |
@@ -85,7 +93,6 @@ initial WCS. |
 | Parameter          | Type  | Description                                                                                                                                |
 |---------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | pixel               | bool  | If true, use a pixel (tophat) function rather than a delta function to be convolved with the PSF in order to build the model.            |
-| contour_grid     | bool  | A new method being developed to generate the adaptive grid. Seems to be better! TODO: Consider replacing the default method.             |
 | subtract_background      | bool  | If False, add an extra parameter that fits for the mean sky background level. If true, subtract the SKYMEAN from the image header. |
 
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ initial WCS. |
 | Parameter          | Type  | Description                                                                                                                                |
 |---------------------|-------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | pixel               | bool  | If true, use a pixel (tophat) function rather than a delta function to be convolved with the PSF in order to build the model.            |
-| makecontourGrid     | bool  | A new method being developed to generate the adaptive grid. Seems to be better! TODO: Consider replacing the default method.             |
-| fit_background      | bool  | If true, add an extra parameter that fits for the mean sky background level. Should be false since the exact number is in the image header. |
+| contour_grid     | bool  | A new method being developed to generate the adaptive grid. Seems to be better! TODO: Consider replacing the default method.             |
+| subtract_background      | bool  | If False, add an extra parameter that fits for the mean sky background level. If true, subtract the SKYMEAN from the image header. |
 
 
 ### Not currently used, to be removed.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ To actually have the code serve your specific needs, you can modify the yaml fil
                         interpolation of the image. See make_contour_grid for
                         a more detailed explanation.
               single: Place a single grid point. This is for sanity checking
-                      that the algroithm is drawing points where expected.                                              |
+                      that the algroithm is drawing points where expected.
+              none: Don't generate a background model at all. Useful for
+              testing just the PSF photometry of the SN if
+              running on a star, for instance. |                                              |
 | band                   | str    | Which Roman passband to use.                                                                                                   |
 | testnum                | int    | Total number of images to utilize in the SMP algorithm.                                                                        |
 | detim                  | int    | Number of images with a SN detection in them. Rule of thumb, this should be 1/2 or less of testnum.                           |
@@ -81,7 +84,6 @@ For testing the algorithm, it is often beneficial to simulate our own galaxy and
 | do_xshift              | bool   | If true, successive images have their centers offset (as they will be for real Roman images).                                     |
 | use_roman              | bool   | If true, use a Galsim-generated Roman PSF to create images. If false, use an analytic Airy PSF.                                   |
 | mismatch_seds          | bool   | If true, intentionally use a different SED to generate the SN than to fit it later. Useful for testing how much the SED affects the fit. |
-| turn_grid_off          | bool   | If true, don't generate a background model at all. Useful for testing just the PSF photometry of the SN if bg_gal_flux is set to zero. |
 | single_grid_point      | bool   | See below.                                                                                                                           |
 | deltafcn_profile       | bool   | If true, the galaxy is no longer a realistic galaxy profile and instead a Dirac delta function. Combined with single_grid_point, it is hypothetically possible for the algorithm to perfectly recover the background by fitting a Dirac delta to a Dirac delta at the exact same location. TODO: explain this better. |
 |sim_ra, sim_dec         | float  | RA and DEC for simulated SN in degrees. |

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -132,7 +132,6 @@ def main():
     make_exact = config['make_exact']
     avoid_non_linearity = config['avoid_non_linearity']
     deltafcn_profile = config['deltafcn_profile']
-    single_grid_point = config['single_grid_point']
     do_xshift = config['do_xshift']
     do_rotation = config['do_rotation']
     noise = config['noise']
@@ -154,7 +153,9 @@ def main():
     sim_gal_dec_offset = config['sim_gal_dec_offset']
 
     grid_type = config['grid_type']
-
+    er = f'{grid_type} is not a recognized grid type. Available options are '
+    er += 'regular, adaptive, contour, or single. Details in documentation.'
+    assert grid_type in ['regular', 'adaptive', 'contour', 'single'], er
 
     # PSF for when not using the Roman PSF:
     lam = 1293  # nm
@@ -163,7 +164,7 @@ def main():
                                       aberrations=aberrations)
 
     if make_exact:
-        assert single_grid_point
+        assert grid_type == 'single'
     if avoid_non_linearity:
         assert deltafcn_profile
     assert num_detect_images <= num_total_images
@@ -184,7 +185,7 @@ def main():
                            use_roman, subtract_background, turn_grid_off,
                            make_initial_guess, initial_flux_guess,
                            weighting, method, grid_type,
-                           single_grid_point, pixel, source_phot_ops,
+                           pixel, source_phot_ops,
                            lc_start, lc_end, do_xshift, bg_gal_flux,
                            do_rotation, airy, mismatch_seds, deltafcn_profile,
                            noise, check_perfection, avoid_non_linearity,

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -150,7 +150,7 @@ def main():
     source_phot_ops = config['source_phot_ops']
     mismatch_seds = config['mismatch_seds']
     fetch_SED = config['fetch_SED']
-    make_contour_grid = config['makecontourGrid']
+    contour_grid = config['contour_grid']
     initial_flux_guess = config['initial_flux_guess']
     deltafcn_profile = config['deltafcn_profile']
     sim_gal_ra_offset = config['sim_gal_ra_offset']
@@ -185,7 +185,7 @@ def main():
                            use_roman, subtract_background, turn_grid_off,
                            adaptive_grid,
                            make_initial_guess, initial_flux_guess,
-                           weighting, method, make_contour_grid,
+                           weighting, method, contour_grid,
                            single_grid_point, pixel, source_phot_ops,
                            lc_start, lc_end, do_xshift, bg_gal_flux,
                            do_rotation, airy, mismatch_seds, deltafcn_profile,

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -142,7 +142,6 @@ def main():
     pixel = config['pixel']
     roman_path = config['roman_path']
     sn_path = config['sn_path']
-    turn_grid_off = config['turn_grid_off']
     bg_gal_flux = config['bg_gal_flux']
     source_phot_ops = config['source_phot_ops']
     mismatch_seds = config['mismatch_seds']
@@ -155,7 +154,8 @@ def main():
     grid_type = config['grid_type']
     er = f'{grid_type} is not a recognized grid type. Available options are '
     er += 'regular, adaptive, contour, or single. Details in documentation.'
-    assert grid_type in ['regular', 'adaptive', 'contour', 'single'], er
+    assert grid_type in ['regular', 'adaptive', 'contour',
+                         'single', 'none'], er
 
     # PSF for when not using the Roman PSF:
     lam = 1293  # nm
@@ -182,7 +182,7 @@ def main():
             confusion_metric, X, cutout_wcs_list, sim_lc = \
             run_one_object(ID, object_type, num_total_images, num_detect_images, roman_path,
                            sn_path, size, band, fetch_SED, use_real_images,
-                           use_roman, subtract_background, turn_grid_off,
+                           use_roman, subtract_background,
                            make_initial_guess, initial_flux_guess,
                            weighting, method, grid_type,
                            pixel, source_phot_ops,

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -125,7 +125,6 @@ def main():
 
     config = load_config(config_path)
 
-    npoints = config['npoints']
     size = config['size']
     use_real_images = config['use_real_images']
     use_roman = config['use_roman']
@@ -139,7 +138,6 @@ def main():
     noise = config['noise']
     method = config['method']
     make_initial_guess = config['make_initial_guess']
-    adaptive_grid = config['adaptive_grid']
     subtract_background = config['subtract_background']
     weighting = config['weighting']
     pixel = config['pixel']
@@ -150,11 +148,12 @@ def main():
     source_phot_ops = config['source_phot_ops']
     mismatch_seds = config['mismatch_seds']
     fetch_SED = config['fetch_SED']
-    contour_grid = config['contour_grid']
     initial_flux_guess = config['initial_flux_guess']
     deltafcn_profile = config['deltafcn_profile']
     sim_gal_ra_offset = config['sim_gal_ra_offset']
     sim_gal_dec_offset = config['sim_gal_dec_offset']
+
+    grid_type = config['grid_type']
 
 
     # PSF for when not using the Roman PSF:
@@ -183,9 +182,8 @@ def main():
             run_one_object(ID, object_type, num_total_images, num_detect_images, roman_path,
                            sn_path, size, band, fetch_SED, use_real_images,
                            use_roman, subtract_background, turn_grid_off,
-                           adaptive_grid,
                            make_initial_guess, initial_flux_guess,
-                           weighting, method, contour_grid,
+                           weighting, method, grid_type,
                            single_grid_point, pixel, source_phot_ops,
                            lc_start, lc_end, do_xshift, bg_gal_flux,
                            do_rotation, airy, mismatch_seds, deltafcn_profile,

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ background_level: 0
 band: Y106
 bg_gal_flux: 100000.0
 check_perfection: false
+contour_grid: false
 deltafcn_profile: false
 do_rotation: true
 do_xshift: true
@@ -11,7 +12,7 @@ fetch_SED: true
 initial_flux_guess: 3000
 make_exact: false
 make_initial_guess: true
-contour_grid: false
+makecontourGrid: false
 method: lsqr
 mismatch_seds: false
 noise: 0

--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,6 @@ fetch_SED: true
 initial_flux_guess: 3000
 make_exact: false
 make_initial_guess: true
-makecontourGrid: false
 method: lsqr
 mismatch_seds: false
 noise: 0
@@ -22,7 +21,7 @@ roman_path: /hpc/group/cosmology/OpenUniverse2024
 sim_gal_dec_offset: 1e-5
 sim_gal_ra_offset: 1e-5
 single_grid_point: false
-size: 11
+size: 31
 sn_path: /hpc/group/cosmology/OpenUniverse2024/roman_rubin_cats_v1.1.2_faint/
 source_phot_ops: true
 spline_grid: false

--- a/config.yaml
+++ b/config.yaml
@@ -8,11 +8,10 @@ deltafcn_profile: false
 do_rotation: true
 do_xshift: true
 fetch_SED: true
-subtract_background: true
 initial_flux_guess: 3000
 make_exact: false
 make_initial_guess: true
-makecontourGrid: true
+contour_grid: false
 method: lsqr
 mismatch_seds: false
 noise: 0
@@ -22,10 +21,11 @@ roman_path: /hpc/group/cosmology/OpenUniverse2024
 sim_gal_dec_offset: 1e-5
 sim_gal_ra_offset: 1e-5
 single_grid_point: false
-size: 31
+size: 11
 sn_path: /hpc/group/cosmology/OpenUniverse2024/roman_rubin_cats_v1.1.2_faint/
 source_phot_ops: true
 spline_grid: false
+subtract_background: true
 turn_grid_off: false
 use_real_images: true
 use_roman: true

--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,7 @@ size: 31
 sn_path: /hpc/group/cosmology/OpenUniverse2024/roman_rubin_cats_v1.1.2_faint/
 source_phot_ops: true
 spline_grid: false
-subtract_background: true
+fit_background: false
 turn_grid_off: false
 use_real_images: true
 use_roman: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,8 @@
-adaptive_grid: true
 avoid_non_linearity: false
 background_level: 0
 band: Y106
 bg_gal_flux: 100000.0
 check_perfection: false
-contour_grid: false
 deltafcn_profile: false
 do_rotation: true
 do_xshift: true
@@ -30,3 +28,4 @@ turn_grid_off: false
 use_real_images: true
 use_roman: true
 weighting: true
+grid_type: contour


### PR DESCRIPTION
1. [x] The overly complicated, multipurpose function `local_grid` has been split into 3 functions, `regular_grid`, `make_adaptive_grid`, and `make_contour_grid`.
2. [x] The tests written for local_grid have been switched so that they now run on these new functions, which still pass.
3. [x] Added documentation (with some fun schematics!) for these functions.
4. [x] Need to update the README
5. [x] Need to change `regular_grid` ---> `make_regular_grid` for symmetry.