### PR TITLE
Fixing snappl and all grid functions are finally refactored.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "extern/snappl"]
-	path = extern/snappl
-	url = https://github.com/Roman-Supernova-PIT/snappl.git

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -25,6 +25,7 @@ import pandas as pd
 from roman_imsim.utils import roman_utils
 import scipy.sparse as sp
 from simulation import simulate_images
+import snappl
 from snappl.logger import Lager
 from snappl.config import Config
 from snappl.image import OpenUniverse2024FITSImage
@@ -178,6 +179,8 @@ def main():
 
     # run one supernova function TODO
     for ID in SNID:
+        Lager.debug('Snappl version:')
+        Lager.debug(snappl.__version__)
         flux, sigma_flux, images, sumimages, exposures, ra_grid, dec_grid, wgt_matrix, \
             confusion_metric, X, cutout_wcs_list, sim_lc = \
             run_one_object(ID, object_type, num_total_images, num_detect_images, roman_path,

--- a/RomanASP.py
+++ b/RomanASP.py
@@ -26,8 +26,10 @@ from roman_imsim.utils import roman_utils
 import scipy.sparse as sp
 from simulation import simulate_images
 import snappl
-from snappl.logger import Lager
-from snappl.config import Config
+#from snappl.logger import Lager
+from snpit_utils.logger import SNLogger as Lager
+#from snappl.config import Config
+from snpit_utils.config import Config
 from snappl.image import OpenUniverse2024FITSImage
 import warnings
 import yaml

--- a/simulation.py
+++ b/simulation.py
@@ -20,7 +20,10 @@ from roman_imsim.utils import roman_utils
 from astropy.utils.exceptions import AstropyWarning
 from erfa import ErfaWarning
 from astropy.nddata import Cutout2D
-from snappl.logger import Lager
+#from snappl.logger import Lager
+from snpit_utils.logger import SNLogger as Lager
+#from snappl.config import Config
+from snpit_utils.config import Config
 
 # This supresses a warning because the Open Universe Simulations dates are not
 # FITS compliant.


### PR DESCRIPTION
Working with Rob, I:
1. [ ] Changed snappl from a git submodule to a package
2. [ ] Ironed out origin differences betweeen galsim and astropy/snappl
3. [ ] All test_make_grid functions test both galsim and astropy wcs methods.
4. [ ] Whenever you use a galsim wcs for making the grid a warning is passed that this will eventually be no longer allowed.
5. [ ] makeGrid runs on snappl image objects!!
